### PR TITLE
rework attribute dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0]
+
+* Dropped AttributeDict for a plain dict object for extra keys
+* Added a number of utility functions around aliases and field metadata
+* Added `proxy` property to ConfigExtra for typed access of the Acessproxy
+
 ## [0.4.2]
 
 * Fixed an issue where `to_dict` did not respect field aliases when converting configuration data to a dictionary. Now, fields with defined aliases will use those aliases as keys in the resulting dictionary.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -171,7 +171,7 @@ from dataclasses import dataclass
 from typing import Annotated
 
 @dataclass
-class Config:
+class ConfigSchema:
     """This is a config docstring."""
     host: Annotated[str, "The host of the server"] = "localhost"
     port: Annotated[int, "The port of the server"] = 8080
@@ -204,10 +204,10 @@ from eyconf.decorators import allow_additional
 
 @allow_additional
 @dataclass
-class Config:
+class ConfigSchema:
     known_field: int = 42
 
-config = EyConf(schema=Config)
+config = EyConf(schema=ConfigSchema)
 ```
 
 We can now edit the config yaml file to include additional fields:
@@ -236,10 +236,10 @@ from dataclasses import dataclass
 from eyconf.config import ConfigExtra
 
 @dataclass
-class Config:
+class ConfigSchema:
     known_field: int = 42
 
-config = ConfigExtra(Config())
+config = ConfigExtra(ConfigSchema())
 config.data.extra_field = 43
 config.data["extra_field_2"] = 44 # also enables dict style access
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eyconf"
-version = "0.4.2"
+version = "0.5.0"
 authors = [{ name = "Sebastian B. Mohr", email = "sebastian@mohrenclan.de" }]
 description = "Easy Yaml based Configuration for Python"
 readme = "README.md"
@@ -21,11 +21,9 @@ classifiers = [
 ]
 dependencies = ["typing-extensions", "pyyaml", "jsonschema"]
 
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
 
 [project.optional-dependencies]
 typed = ["mypy", "types-pyyaml","types-jsonschema"]
@@ -46,7 +44,6 @@ cli = ["typer"]
 [tool.hatch.build.targets.wheel]
 packages = ["src/eyconf"]
 
-
 [tool.ruff]
 include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]
 target-version = "py310"
@@ -55,7 +52,6 @@ target-version = "py310"
 select = ["I", "D", "F", "UP"]
 ignore = ["D104", "D100"]
 fixable = ["ALL"]
-
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/**" = ["D", "I", "S", "W"]
@@ -70,7 +66,6 @@ addopts = ["--import-mode=importlib", "--cov=."]
 filterwarnings = ["error", "ignore::DeprecationWarning"]
 pythonpath = ["."]
 log_level = "DEBUG"
-
 
 [tool.coverage.report]
 omit = ["*/tests/*", "*/docs/*"]

--- a/src/eyconf/config/base.py
+++ b/src/eyconf/config/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from dataclasses import asdict, fields, is_dataclass
+from dataclasses import asdict, is_dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -24,7 +24,7 @@ from eyconf.type_utils import (
     is_dataclass_instance,
     is_dataclass_type,
 )
-from eyconf.utils import dataclass_from_dict
+from eyconf.utils import dataclass_from_dict, dict_items_resolve_aliases
 from eyconf.validation import to_json_schema, validate, validate_json
 
 if TYPE_CHECKING:
@@ -113,18 +113,7 @@ class Config(Generic[D]):
             """
             target_annotations = get_type_hints_resolve_namespace(target_type)
 
-            # Rewrite key, from alias to field name
-            alias_to_fields = {
-                f.metadata["alias"]: f
-                for f in fields(target_type)
-                if "alias" in f.metadata
-            }
-
-            for key, value in update_data.items():
-                # resolve to attribute style keys (alias->non-alias)
-                if alias_field := alias_to_fields.get(key):
-                    key = alias_field.name
-
+            for key, value in dict_items_resolve_aliases(update_data, target_type):
                 if hasattr(target, key):
                     current_value = getattr(target, key)
 

--- a/src/eyconf/config/base.py
+++ b/src/eyconf/config/base.py
@@ -102,8 +102,13 @@ class Config(Generic[D]):
 
             for key, value in update_data.items():
                 # resolve if key has an alias
+                orig_key = key
                 if alias_field := alias_fields.get(key):
                     key = alias_field.name
+
+                # TODO: marker
+                # if key in ["import", "import_"]:
+                # breakpoint()
 
                 if hasattr(target, key):
                     # folders : dict[str, InboxFolder]
@@ -141,7 +146,7 @@ class Config(Generic[D]):
                 else:
                     # Non-schema fields
                     self._update_additional(
-                        target, key, value, _current_path=_current_path
+                        target, orig_key, value, _current_path=_current_path
                     )
 
         old_data = deepcopy(self._data)

--- a/src/eyconf/config/base.py
+++ b/src/eyconf/config/base.py
@@ -106,7 +106,8 @@ class Config(Generic[D]):
             update_data : dict
                 The update data to apply.
             path : list[tuple[DataclassInstance, str]] | None
-                The current path in the dataclass tree (root-to-leaf). [0] is parent instance,
+                The current path in the dataclass tree (root-to-leaf).
+                [0] is parent instance,
                 [1] is attr key used to access the target from from its parent. E.g.
                 [(root_instance, "child_field"), (child_instance, "grandchild_field")]
             """

--- a/src/eyconf/config/extra_fields.py
+++ b/src/eyconf/config/extra_fields.py
@@ -14,8 +14,10 @@ from eyconf.type_utils import (
     iter_dataclass_type,
 )
 from eyconf.utils import (
+    Metadata,
     dataclass_from_dict,
     merge_dicts,
+    metadata_fields_from_dataclass,
 )
 from eyconf.validation import validate
 from eyconf.validation._to_json import to_json_schema
@@ -53,13 +55,9 @@ class AccessProxy(Generic[D]):
 
     @property
     @cache
-    def _fields_metadata(self) -> dict[str, MappingProxyType[Any, Any]]:
+    def _fields_metadata(self) -> dict[str, Metadata]:
         """Get the fields of the current dataclass schema."""
-        dataclass_fields = fields(self._data)
-        fieldname_to_metadata = {
-            f.name: f.metadata for f in dataclass_fields if f.metadata
-        }
-        return fieldname_to_metadata
+        return metadata_fields_from_dataclass(self._data)
 
     def _resolve_attr_to_dict_key(self, attr_key: str) -> str:
         """Resolve an attribute key to its dict key using aliasing."""
@@ -219,7 +217,7 @@ class ConfigExtra(Config[D]):
         dict_key_path = []
         for target, attr_key in path:
             # resolve attr_key to dict_key using aliasing
-            field_metadata = {f.name: f.metadata for f in fields(target) if f.metadata}
+            field_metadata = metadata_fields_from_dataclass(target)
             dict_key = field_metadata.get(attr_key, {}).get("alias", attr_key)
             dict_key_path.append(dict_key)
 

--- a/src/eyconf/config/extra_fields.py
+++ b/src/eyconf/config/extra_fields.py
@@ -2,15 +2,10 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from dataclasses import dataclass, is_dataclass
+from dataclasses import is_dataclass
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from eyconf.asdict import asdict_with_aliases
-from eyconf.decorators import (
-    _aliases_map,
-    _get_attr_resolve_alias,
-    _set_attr_resolve_alias,
-)
 from eyconf.type_utils import is_dataclass_type, iter_dataclass_type
 from eyconf.utils import (
     dataclass_from_dict,

--- a/src/eyconf/config/extra_fields.py
+++ b/src/eyconf/config/extra_fields.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from dataclasses import fields, is_dataclass
+from dataclasses import is_dataclass
 from functools import cache
-from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from eyconf.asdict import asdict_with_aliases

--- a/src/eyconf/config/extra_fields.py
+++ b/src/eyconf/config/extra_fields.py
@@ -61,28 +61,28 @@ class AccessProxy(Generic[D]):
             )
 
     @property
-    def dict_path(self) -> list[str]:
+    def _dict_path(self) -> list[str]:
         """Get the full dict path to this AccessProxy."""
         if self._dict_key is None or self._parent is None:
             return []
         else:
-            return self._parent.dict_path + [self._dict_key]
+            return self._parent._dict_path + [self._dict_key]
 
     @property
-    def attr_path(self) -> list[str]:
+    def _attr_path(self) -> list[str]:
         """Get the full attribute path to this AccessProxy."""
         if self._parent is None or self._attr_key is None:
             return []
         else:
-            return self._parent.attr_path + [self._attr_key]
+            return self._parent._attr_path + [self._attr_key]
 
     @property
-    def root_schema(self) -> type[D]:
+    def _root_schema(self) -> type[D]:
         """Get the root schema dataclass."""
         if self._parent is None:
             return type(self._data)
         else:
-            return self._parent.root_schema
+            return self._parent._root_schema
 
     def to_dict(self) -> dict:
         """Convert the AccessProxy to a standard dictionary."""
@@ -94,7 +94,7 @@ class AccessProxy(Generic[D]):
     def __getattr__(self, attr_key: str) -> Any:
         """Get field via attribute style access (non-aliased keys)."""
         dict_key = resolve_alias_attr_path_to_dict_path(
-            self.root_schema, self.attr_path + [attr_key]
+            self._root_schema, self._attr_path + [attr_key]
         )[-1]
         try:
             data = getattr(self._data, attr_key)
@@ -123,14 +123,14 @@ class AccessProxy(Generic[D]):
                 setattr(self._data, attr_key, value)
             else:
                 dict_key = resolve_alias_attr_path_to_dict_path(
-                    self.root_schema, self.attr_path + [attr_key]
+                    self._root_schema, self._attr_path + [attr_key]
                 )[-1]
                 self._extra_data[dict_key] = value
 
     def __getitem__(self, dict_key: str) -> Any:
         """Get field via dict style acces (alias)."""
         attr_key = resolve_alias_dict_path_to_attr_path(
-            self.root_schema, self.dict_path + [dict_key]
+            self._root_schema, self._dict_path + [dict_key]
         )[-1]
         if hasattr(self._data, attr_key):
             return self.__getattr__(attr_key)
@@ -140,7 +140,7 @@ class AccessProxy(Generic[D]):
     def __setitem__(self, dict_key: str, value: Any) -> None:
         """Set field via dict style access (alias)."""
         attr_key = resolve_alias_dict_path_to_attr_path(
-            self.root_schema, self.dict_path + [dict_key]
+            self._root_schema, self._dict_path + [dict_key]
         )[-1]
         if hasattr(self._data, attr_key):
             self.__setattr__(attr_key, value)

--- a/src/eyconf/config/extra_fields.py
+++ b/src/eyconf/config/extra_fields.py
@@ -64,9 +64,9 @@ class AccessProxy(Generic[D]):
 
     def _resolve_dict_to_attr_key(self, dict_key: str) -> str:
         """Resolve a dict key to its attribute key using aliasing."""
-        for attr, metadata in self._fields_metadata.items():
+        for attr_key, metadata in self._fields_metadata.items():
             if metadata.get("alias") == dict_key:
-                return attr
+                return attr_key
         return dict_key
 
     def _to_dict(self) -> dict:

--- a/src/eyconf/decorators.py
+++ b/src/eyconf/decorators.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable
-from dataclasses import fields, is_dataclass
+from dataclasses import is_dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -12,10 +12,12 @@ from typing import (
     runtime_checkable,
 )
 
+from eyconf.type_utils import is_dataclass_type
+from eyconf.utils import get_metadata
+
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
 
-from eyconf.type_utils import is_dataclass_type
 
 T = TypeVar("T")
 D = TypeVar("D", bound="DataclassInstance")
@@ -37,7 +39,7 @@ class DictSetAccess(Protocol):
 
 def _aliases_map(cls: DataclassInstance) -> dict[str, str]:
     """Get mapping of aliases to field names for a dataclass."""
-    return {f.metadata["alias"]: f.name for f in fields(cls) if "alias" in f.metadata}
+    return {m["alias"]: f.name for f, m in get_metadata(cls) if "alias" in m}
 
 
 def _get_attr_resolve_alias(self: DataclassInstance, key: str) -> Any:

--- a/src/eyconf/type_utils.py
+++ b/src/eyconf/type_utils.py
@@ -92,6 +92,11 @@ def is_dataclass_type(obj: Any) -> TypeGuard[type]:
     return is_dataclass(obj) and isinstance(obj, type)
 
 
+def is_dataclass_instance(obj: Any) -> TypeGuard[DataclassInstance]:
+    """Check if an object is a dataclass instance."""
+    return is_dataclass(obj) and not isinstance(obj, type)
+
+
 def iter_dataclass_type(schema: type[D]) -> Iterator[type[DataclassInstance]]:
     """Iterate over all dataclass nested instances in the given dataclass type.
 

--- a/src/eyconf/utils.py
+++ b/src/eyconf/utils.py
@@ -13,8 +13,6 @@ from typing import (
     get_type_hints,
 )
 
-from eyconf.type_utils import iter_dataclass_type
-
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
 

--- a/src/eyconf/utils.py
+++ b/src/eyconf/utils.py
@@ -5,10 +5,9 @@ from dataclasses import fields, is_dataclass
 from types import NoneType, UnionType
 from typing import (
     TYPE_CHECKING,
-    Annotated,
     Any,
-    TypeVar,
     TypedDict,
+    TypeVar,
     get_args,
     get_origin,
     get_type_hints,

--- a/src/eyconf/utils.py
+++ b/src/eyconf/utils.py
@@ -5,12 +5,15 @@ from dataclasses import fields, is_dataclass
 from types import NoneType, UnionType
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     TypeVar,
     get_args,
     get_origin,
     get_type_hints,
 )
+
+from eyconf.type_utils import iter_dataclass_type
 
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
@@ -128,3 +131,113 @@ def _dataclass_from_dict_inner(target_type: type, data: Any) -> Any:
 
     # Handle primitive types
     return data
+
+
+def resolve_alias_attr_path_to_dict_path(
+    schema: type[D],
+    attr_path: list[str],
+) -> list[str]:
+    """Translate between attribute- and dict- style access.
+
+    Parameters
+    ----------
+    schema : type[D]
+        The dataclass schema to use for alias resolution.
+    attr_path : list[str]
+        The path in attribute notation.
+
+    Returns
+    -------
+    list[str]
+        The translated path in dict notation.
+    """
+    dict_path = []
+    current_schema = schema
+    for attr in attr_path:
+        if current_schema is not None:
+            aliases = {
+                f.name: f.metadata["alias"]
+                for f in fields(current_schema)
+                if "alias" in f.metadata
+            }
+        else:
+            # we set to None once we traverse out of the schema
+            dict_path.append(attr)
+            continue
+
+        if attr in aliases:
+            dict_path.append(aliases[attr])
+        else:
+            dict_path.append(attr)
+
+        # Update current schema for next iteration
+        type_hints = get_type_hints(current_schema)
+        if attr in type_hints:
+            next_type = type_hints[attr]
+            origin = get_origin(next_type)
+            if origin is Annotated:
+                next_type = get_args(next_type)[0]
+            if is_dataclass(next_type):
+                current_schema = next_type
+            else:
+                current_schema = None
+        else:
+            current_schema = None
+
+    return dict_path
+
+
+def resolve_alias_dict_path_to_attr_path(
+    schema: type[D],
+    dict_path: list[str],
+) -> list[str]:
+    """Translate between attribute- and dict- style access.
+
+    Parameters
+    ----------
+    schema : type[D]
+        The dataclass schema to use for alias resolution.
+    dict_path : list[str]
+        The path in dict notation.
+
+    Returns
+    -------
+    list[str]
+        The translated path in attribute notation.
+    """
+    attr_path = []
+    current_schema = schema
+    for dict_key in dict_path:
+        if current_schema is not None:
+            aliases = {
+                f.metadata["alias"]: f.name
+                for f in fields(current_schema)
+                if "alias" in f.metadata
+            }
+        else:
+            # we set to None once we traverse out of the schema
+            attr_path.append(dict_key)
+            continue
+
+        if dict_key in aliases:
+            attr_path.append(aliases[dict_key])
+            attr = aliases[dict_key]
+        else:
+            attr_path.append(dict_key)
+            attr = dict_key
+
+        # Update current schema for next iteration
+        type_hints = get_type_hints(current_schema)
+        if attr in type_hints:
+            next_type = type_hints[attr]
+            origin = get_origin(next_type)
+            if origin is Annotated:
+                next_type = get_args(next_type)[0]
+            if is_dataclass(next_type):
+                current_schema = next_type
+            else:
+                current_schema = None
+        else:
+            current_schema = None
+
+    return attr_path

--- a/src/eyconf/utils.py
+++ b/src/eyconf/utils.py
@@ -170,7 +170,7 @@ def dict_items_resolve_aliases(
 
     This resolve to attribute style keys (alias->non-alias).
     """
-    alias_to_fields = {
+    dict_key_to_attr_key = {
         m["alias"]: f.name for f, m in get_metadata(type) if "alias" in m
     }
-    return ((alias_to_fields.get(key, key), value) for key, value in data.items())
+    return ((dict_key_to_attr_key.get(key, key), value) for key, value in data.items())

--- a/src/eyconf/utils.py
+++ b/src/eyconf/utils.py
@@ -23,13 +23,22 @@ D = TypeVar("D", bound="DataclassInstance")
 def merge_dicts(a: dict, b: dict, path=[]):
     """Merge dict b into dict a, raising an exception on conflicts."""
     for key in b:
+        val_b = b[key]
         if key in a:
             if isinstance(a[key], dict) and isinstance(b[key], dict):
                 merge_dicts(a[key], b[key], path + [str(key)])
-            elif a[key] != b[key]:
-                raise Exception("Conflict at " + ".".join(path + [str(key)]))
+            val_a = a[key]
+            if isinstance(val_a, dict) and isinstance(val_b, dict):
+                merge_dicts(val_a, val_b, path + [str(key)])
+            elif val_a != val_b:
+                raise Exception(
+                    "Conflict at "
+                    + ".".join(path + [str(key)])
+                    + f": {val_a} != {val_b}"
+                )
         else:
-            a[key] = b[key]
+            a[key] = val_b
+
     return a
 
 

--- a/src/eyconf/validation/_to_json.py
+++ b/src/eyconf/validation/_to_json.py
@@ -13,6 +13,7 @@ from typing_extensions import NotRequired
 from eyconf.constants import primitive_type_mapping
 from eyconf.decorators import check_allows_additional
 from eyconf.type_utils import get_type_hints_resolve_namespace
+from eyconf.utils import metadata_fields_from_dataclass
 
 SchemaType = dict[str, Any] | dict[str, str] | dict[Any, Any]
 
@@ -57,9 +58,7 @@ def to_json_schema(
 
     # Get type hints for the TypedDict
     type_hints = get_type_hints_resolve_namespace(type, include_extras=True)
-    dataclass_fields = fields(type) if is_dataclass(type) else {}
-    fieldname_to_metadata = {f.name: f.metadata for f in dataclass_fields if f.metadata}
-
+    fieldname_to_metadata = metadata_fields_from_dataclass(type)
     # Add the type hints to the schema
     for field_name, field_type in type_hints.items():
         if alias := fieldname_to_metadata.get(field_name, {}).get("alias"):

--- a/src/eyconf/validation/_to_json.py
+++ b/src/eyconf/validation/_to_json.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from dataclasses import fields, is_dataclass
+from dataclasses import is_dataclass
 from functools import cache
 from types import NoneType, UnionType
 from typing import Annotated, Any, ClassVar, Literal, Union, get_args, get_origin

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -143,6 +143,24 @@ class TestAlias:
         assert config.data.attr_field == 100
         assert config.data.str_field == "Test"
 
+    def test_extra_data_nested_aliased(self):
+        @dataclass
+        class ConfigAliasedParent:
+            import_: Config42 = field(
+                default_factory=lambda: Config42(), metadata={"alias": "import"}
+            )
+
+        config = ConfigExtra(ConfigAliasedParent())
+        assert config.data.import_.int_field == 42
+        assert config.data["import"].int_field == 42
+
+        config.data.import_.new_field = "New Value"
+        assert config.data.import_.new_field == "New Value"
+        assert config.data._extra_data["import"]["new_field"] == "New Value"
+        assert config._extra_data["import"]["new_field"] == "New Value"
+        assert config.data["import"].new_field == "New Value"
+        assert config.data["import"]["new_field"] == "New Value"
+
 
 class TestToDictAlias:
     """Test that aliases are resolved properly when using the to_dict function."""

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -11,10 +11,6 @@ from eyconf.validation import (
     MultiConfigurationError,
     validate,
 )
-from eyconf.utils import (
-    resolve_alias_attr_path_to_dict_path,
-    resolve_alias_dict_path_to_attr_path,
-)
 
 T = TypeVar("T", bound=Any)
 
@@ -68,30 +64,6 @@ class NestedAliasConfig:
 class AliasDictConfig:
     attr_field: int = field(metadata={"alias": "dict_field"})
     str_field: str = "FortyTwo!"
-
-
-class TestPathHelper:
-    def test_resolve_alias_attr_to_dict(self):
-        dict_path = resolve_alias_attr_path_to_dict_path(
-            AliasConfig, ["attr_field", "str_field"]
-        )
-        assert dict_path == ["dict_field", "str_field"]
-
-        dict_path_nested = resolve_alias_attr_path_to_dict_path(
-            NestedAliasConfig, ["nested", "attr_field", "other_field"]
-        )
-        assert dict_path_nested == ["nested", "dict_field", "other_field"]
-
-    def test_resolve_alias_dict_to_attr(self):
-        attr_path = resolve_alias_dict_path_to_attr_path(
-            AliasConfig, ["dict_field", "str_field"]
-        )
-        assert attr_path == ["attr_field", "str_field"]
-
-        attr_path_nested = resolve_alias_dict_path_to_attr_path(
-            NestedAliasConfig, ["nested", "dict_field", "other_field"]
-        )
-        assert attr_path_nested == ["nested", "attr_field", "other_field"]
 
 
 class TestAlias:

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -124,14 +124,14 @@ class TestAlias:
 
         config = ConfigExtra(ConfigAliasedParent())
         assert config.data.import_.int_field == 42
-        assert config.data["import"].int_field == 42
+        assert config.proxy["import"].int_field == 42
 
-        config.data.import_.new_field = "New Value"
-        assert config.data.import_.new_field == "New Value"
-        assert config.data._extra_data["import"]["new_field"] == "New Value"
+        config.proxy.import_.new_field = "New Value"
+        assert config.proxy.import_.new_field == "New Value"
+        assert config.proxy._extra_data["import"]["new_field"] == "New Value"
         assert config._extra_data["import"]["new_field"] == "New Value"
-        assert config.data["import"].new_field == "New Value"
-        assert config.data["import"]["new_field"] == "New Value"
+        assert config.proxy["import"].new_field == "New Value"
+        assert config.proxy["import"]["new_field"] == "New Value"
 
 
 class TestToDictAlias:

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -11,7 +11,10 @@ from eyconf.validation import (
     MultiConfigurationError,
     validate,
 )
-
+from eyconf.utils import (
+    resolve_alias_attr_path_to_dict_path,
+    resolve_alias_dict_path_to_attr_path,
+)
 
 T = TypeVar("T", bound=Any)
 
@@ -65,6 +68,30 @@ class NestedAliasConfig:
 class AliasDictConfig:
     attr_field: int = field(metadata={"alias": "dict_field"})
     str_field: str = "FortyTwo!"
+
+
+class TestPathHelper:
+    def test_resolve_alias_attr_to_dict(self):
+        dict_path = resolve_alias_attr_path_to_dict_path(
+            AliasConfig, ["attr_field", "str_field"]
+        )
+        assert dict_path == ["dict_field", "str_field"]
+
+        dict_path_nested = resolve_alias_attr_path_to_dict_path(
+            NestedAliasConfig, ["nested", "attr_field", "other_field"]
+        )
+        assert dict_path_nested == ["nested", "dict_field", "other_field"]
+
+    def test_resolve_alias_dict_to_attr(self):
+        attr_path = resolve_alias_dict_path_to_attr_path(
+            AliasConfig, ["dict_field", "str_field"]
+        )
+        assert attr_path == ["attr_field", "str_field"]
+
+        attr_path_nested = resolve_alias_dict_path_to_attr_path(
+            NestedAliasConfig, ["nested", "dict_field", "other_field"]
+        )
+        assert attr_path_nested == ["nested", "attr_field", "other_field"]
 
 
 class TestAlias:

--- a/tests/test_config_base.py
+++ b/tests/test_config_base.py
@@ -166,15 +166,22 @@ class TestUpdate:
 
         assert conf42.data.int_field == 42
 
-    def test_additional_fields(self):
-        conf42_add = Config(Config42AllowAdditional(), schema=Config42AllowAdditional)
-        # validation should pass, but _setting_ values not.
-        # for that, we have ConfigExtra.
-        with pytest.raises(AttributeError):
-            conf42_add.update({"int_field": 100, "new_field": "I am new!"})
+    def test_update_additional(self, conf_nested):
+        with pytest.raises(AttributeError, match="Cannot set non-schema field"):
+            conf_nested.update({"int_field": 100, "new_field": "I am new!"})
+
+        with pytest.raises(AttributeError, match="nested.new_field"):
+            conf_nested.update(
+                {
+                    "nested": {"int_field": 100, "new_field": "I am new in nested!"},
+                }
+            )
 
     def test_dynamic_fields(self):
-        """Test that dynamic fields are not affected by update."""
+        """Test that dynamic fields are not affected by update.
+
+        This is a bit of an edge case, that should not really be used in practice...
+        """
         conf42_add = Config(Config42AllowAdditional(), schema=Config42AllowAdditional)
         conf42_add.data.dynamic_field = "I am dynamic!"  # type: ignore
 

--- a/tests/test_config_extra_fields.py
+++ b/tests/test_config_extra_fields.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from typing import Any
 import pytest
 from eyconf.config import ConfigExtra
 from eyconf.config.extra_fields import AccessProxy
@@ -170,7 +171,7 @@ class TestAccessProxy:
     @pytest.fixture
     def proxy(self):
         config_data = Config42()
-        extra_data = dict()
+        extra_data: dict[str, Any] = dict()
         return AccessProxy(
             config_data,
             extra_data,
@@ -207,7 +208,7 @@ class TestAccessProxy:
 
     def test_to_dict(self):
         config_data = Config42()
-        extra_data = dict()
+        extra_data: dict[str, Any] = dict()
         proxy = AccessProxy(
             config_data,
             extra_data,

--- a/tests/test_config_extra_fields.py
+++ b/tests/test_config_extra_fields.py
@@ -215,10 +215,27 @@ class TestAccessProxy:
         )
         proxy.foo = "bar"
 
-        result = proxy.to_dict()
+        result = proxy._to_dict()
         expected = {
             "int_field": 42,
             "str_field": "FortyTwo!",
             "foo": "bar",
         }
         assert result == expected
+
+class TestReset:
+    def test_simple(self, conf42: ConfigExtra[Config42]):
+        conf42.update(
+            {
+                "int_field": 100,
+                "str_field": "Updated value!",
+            }
+        )
+
+        assert conf42.data.int_field == 100
+        assert conf42.data.str_field == "Updated value!"
+
+        conf42.reset()
+
+        assert conf42.data.int_field == 42
+        assert conf42.data.str_field == "FortyTwo!"

--- a/tests/test_config_extra_fields.py
+++ b/tests/test_config_extra_fields.py
@@ -44,10 +44,11 @@ class TestDataProperties:
         assert schema_data.str_field == "FortyTwo!"
 
     def test_extra_data(self, conf42: ConfigExtra[Config42]):
-        conf42.data.new_field = "New Value"
-        assert isinstance(conf42.data._extra_data, dict)
-        assert conf42.data._extra_data["new_field"] == "New Value"
-        assert conf42.data.new_field == "New Value"
+        conf42.proxy.new_field = "New Value"
+        assert isinstance(conf42.proxy._extra_data, dict)
+        assert conf42.proxy._extra_data["new_field"] == "New Value"
+        assert conf42.proxy["new_field"] == "New Value"
+        assert conf42.proxy.new_field == "New Value"
 
 
 class TestUpdate:
@@ -56,7 +57,7 @@ class TestUpdate:
 
         config.update({"unknown_field": "I am unknown!"})
 
-        assert config.data.unknown_field == "I am unknown!"
+        assert config.proxy.unknown_field == "I am unknown!"
         assert config._extra_data["unknown_field"] == "I am unknown!"
         with pytest.raises(AttributeError):
             _ = config._data.non_existent_field  # type: ignore[attr-defined]
@@ -125,14 +126,14 @@ class TestUpdate:
         assert config.data.nested.folders["config1"].str_field == "One"
         assert config.data.nested.folders["config2"].int_field == 2
         assert config.data.nested.folders["config2"].str_field == "Two"
-        assert config.data.nested.unknown_field == "I am unknown!"
+        assert config.proxy.nested.unknown_field == "I am unknown!"
 
     @pytest.mark.skip(reason="Changed design, no longer using attribute dicts")
     def test_unknown_nested(self):
         config = ConfigExtra(Config42())
 
         config.update({"level_one": {"level_two": {"level_three": "Deep Value"}}})
-        assert config.data.level_one.level_two.level_three == "Deep Value"
+        assert config.proxy.level_one.level_two.level_three == "Deep Value"
 
 
 class TestToDict:
@@ -149,7 +150,7 @@ class TestToDict:
         assert result == expected
 
     def test_to_dict_with_extra(self, conf42: ConfigExtra[Config42]):
-        conf42.data.new_field = "New Value"
+        conf42.proxy.new_field = "New Value"
         result = conf42.to_dict()
         expected = {
             "int_field": 42,
@@ -222,6 +223,7 @@ class TestAccessProxy:
             "foo": "bar",
         }
         assert result == expected
+
 
 class TestReset:
     def test_simple(self, conf42: ConfigExtra[Config42]):

--- a/tests/test_config_extra_fields.py
+++ b/tests/test_config_extra_fields.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from dataclasses import dataclass, field
 import pytest
 from eyconf.config import ConfigExtra
@@ -48,24 +47,6 @@ class TestDataProperties:
         assert isinstance(conf42.data._extra_data, dict)
         assert conf42.data._extra_data["new_field"] == "New Value"
         assert conf42.data.new_field == "New Value"
-
-    def test_extra_data_nested_aliased(self):
-        @dataclass
-        class ConfigAliasedParent:
-            import_: Config42 = field(
-                default_factory=lambda: Config42(), metadata={"alias": "import"}
-            )
-
-        config = ConfigExtra(ConfigAliasedParent())
-        assert config.data.import_.int_field == 42
-        assert config.data["import"].int_field == 42
-
-        config.data.import_.new_field = "New Value"
-        assert config.data.import_.new_field == "New Value"
-        assert config.data._extra_data["import"]["new_field"] == "New Value"
-        assert config._extra_data["import"]["new_field"] == "New Value"
-        assert config.data["import"].new_field == "New Value"
-        assert config.data["import"]["new_field"] == "New Value"
 
 
 class TestUpdate:

--- a/tests/test_config_extra_fields.py
+++ b/tests/test_config_extra_fields.py
@@ -138,7 +138,7 @@ class TestUpdate:
 
 class TestToDict:
     """Tests for the to_dict method.
-    This should resolve AccessProxy and AttributeDict instances correctly.
+    This should resolve AccessProxy instances correctly.
     """
 
     def test_to_dict_no_extra(self, conf42: ConfigExtra[Config42]):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import fields
+from dataclasses import field, fields
 from pprint import pprint
 from typing import (
     Any,
@@ -489,6 +489,23 @@ class TestToSchema:
             {"type": "string", "enum": ["bar", "baz"]},
             {"type": "string"},
         ]
+
+    def test_alias_handling(self):
+        @dataclass
+        class Schema:
+            bar: int = field(metadata={"alias": "the_bar"})
+            foo: str
+
+        schema = to_json_schema(Schema)
+        assert schema == {
+            "type": "object",
+            "properties": {
+                "foo": {"type": "string"},
+                "the_bar": {"type": "integer"},
+            },
+            "required": ["the_bar", "foo"],
+            "additionalProperties": False,
+        }
 
 
 # This function converts a dataclass to a TypedDict


### PR DESCRIPTION
we likely do not need our attribute dict implementation anymore, a simple dict should be sufficient.

this should also make it easier to deal with aliases,
and fix the issue of the `ConfigExtra` where aliased fields do not match between schema data and extra data.