### PR TITLE
Cli improvments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0]
+
+* Added new subcommands to the CLI integration:`path`, `validate`, `diff`, `reset`
+
 ## [0.5.2]
 
 * Enhanced the eyconf class to use schema-defined default values during validation, preventing errors when fields have defaults but aren't explicitly marked as optional.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "F. Paul Spitzner", email = "github@makeitso.one" },
 ]
 name = "eyconf"
-version = "0.5.2"
+version = "0.6.0"
 description = "Easy Yaml based Configuration for Python"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -48,11 +48,7 @@ cli = ["typer"]
 packages = ["src/eyconf"]
 
 [tool.hatch.build.targets.sdist]
-include = [
-  "/src/**/*.py",
-  "/tests",
-  "/src/eyconf/py.typed"
-]
+include = ["/src/**/*.py", "/tests", "/src/eyconf/py.typed"]
 
 
 [tool.ruff]

--- a/src/eyconf/cli.py
+++ b/src/eyconf/cli.py
@@ -67,9 +67,15 @@ def create_config_cli(
         typer.echo(str(config))
 
     @config_cli.command()
+    def path():
+        """Show the path to the configuration file."""
+        typer.echo(Config.get_file().absolute())
+
+    @config_cli.command()
     def edit():
         """Edit the configuration file in you default editor."""
         asyncio.run(edit_config(Config, *args, **kwargs))
+
     return config_cli
 
 

--- a/src/eyconf/cli.py
+++ b/src/eyconf/cli.py
@@ -13,10 +13,14 @@ app.subcommand(config_cli, name="config")
 """
 
 import asyncio
+import difflib
 import os
+from contextlib import contextmanager
 from typing import Annotated
 
 import typer
+from rich import print
+from rich.text import Text
 from yaml import YAMLError
 
 from eyconf import EYConf
@@ -92,18 +96,55 @@ def create_config_cli(
     @config_cli.command()
     def validate():
         """Validate the configuration file against the schema."""
-        try:
+        with human_readable_validation():
             Config(*args, **kwargs)
-        except MultiConfigurationError as e:
-            for error in e.errors:
-                typer.echo(f"- {error}")
-            raise typer.Exit(1)
-        except YAMLError as e:
-            typer.echo("Invalid YAML file!")
-            typer.echo(e.__class__.__name__)
-            raise typer.Exit(1)
 
         typer.echo("Configuration is valid.")
+
+    @config_cli.command()
+    def diff():
+        """Show differences between current configuration and default values."""
+        with human_readable_validation():
+            from eyconf.generate_yaml import dataclass_to_yaml
+
+            current_config = Config(*args, **kwargs)
+            default_yaml_str = dataclass_to_yaml(current_config._schema())
+            current_yaml_str = current_config.to_yaml()
+
+            current_lines = current_yaml_str.splitlines(keepends=True)
+            default_lines = default_yaml_str.splitlines(keepends=True)
+            # Strange formatting if last lines do not end in newline
+            if not default_yaml_str.endswith("\n"):
+                current_lines[-1] += "\n"
+            if not current_yaml_str.endswith("\n"):
+                default_lines[-1] += "\n"
+
+            diff_lines = difflib.unified_diff(
+                default_lines,
+                current_lines,
+                fromfile="default",
+                tofile="current",
+            )
+            lines = 0
+            for line in diff_lines:
+                text = Text(line)
+                if line.startswith("+") and not line.startswith("+++"):
+                    text.stylize("green")
+                elif line.startswith("-") and not line.startswith("---"):
+                    text.stylize("red")
+                elif line.startswith("@@"):
+                    text.stylize("bold cyan")
+                elif line.startswith("+++"):
+                    text.stylize("bold green")
+                elif line.startswith("---"):
+                    text.stylize("bold red")
+                else:
+                    text.stylize("gray")
+                print(text, end="")  #
+                lines += 1
+
+            if lines == 0:
+                typer.echo("No changes!")
 
     return config_cli
 
@@ -135,3 +176,18 @@ async def edit_config(Config: type[EYConf], *args, **kwargs):
         typer.echo(f"Failed to open the configuration editor: {e}")
 
     await process.wait() if process else None
+
+
+@contextmanager
+def human_readable_validation():
+    """Show human readable exceptions instead of crashing."""
+    try:
+        yield
+    except MultiConfigurationError as e:
+        for error in e.errors:
+            typer.echo(f"- {error}")
+        raise typer.Exit(1)
+    except YAMLError as e:
+        typer.echo("Invalid YAML file!")
+        typer.echo(e.__class__.__name__)
+        raise typer.Exit(1)

--- a/src/eyconf/cli.py
+++ b/src/eyconf/cli.py
@@ -103,7 +103,7 @@ def create_config_cli(
 
     @config_cli.command()
     def diff():
-        """Show differences between current configuration and default values."""
+        """Show differences between current default config values."""
         with human_readable_validation():
             from eyconf.generate_yaml import dataclass_to_yaml
 
@@ -145,6 +145,29 @@ def create_config_cli(
 
             if lines == 0:
                 typer.echo("No changes!")
+
+    @config_cli.command()
+    def reset(
+        force: Annotated[
+            bool,
+            typer.Option(help="Force reset without confirmation."),
+        ] = False,
+    ):
+        """Reset configuration to default values."""
+        # TODO: Support to reset of specific sections
+        if not force:
+            if not typer.confirm(
+                "Are you sure you want to reset the entire configuration?"
+            ):
+                typer.echo("Aborted!")
+                raise typer.Exit(0)
+
+        # Remove file incase of invalid schema/parsing errors
+        path = Config.get_file()
+        if path.exists():
+            os.remove(path)
+        Config(*args, **kwargs)
+        typer.echo("Configuration has been reset to default values.")
 
     return config_cli
 

--- a/src/eyconf/cli.py
+++ b/src/eyconf/cli.py
@@ -55,17 +55,10 @@ def create_config_cli(
     @config_cli.callback(invoke_without_command=True)
     def main(
         ctx: typer.Context,
-        edit: bool = typer.Option(
-            False, "--edit", "-e", help="Edit the configuration."
-        ),
     ):
-        """Edit the plistsync configuration."""
-        if edit:
-            asyncio.run(edit_config(Config, *args, **kwargs))
-        else:
-            # Show help if no subcommand is provided
-            if ctx.invoked_subcommand is None:
-                print(ctx.get_help())
+        # Show help if no subcommand is provided
+        if ctx.invoked_subcommand is None:
+            print(ctx.get_help())
 
     @config_cli.command()
     def ls():
@@ -73,6 +66,10 @@ def create_config_cli(
         config = Config(*args, **kwargs)
         typer.echo(str(config))
 
+    @config_cli.command()
+    def edit():
+        """Edit the configuration file in you default editor."""
+        asyncio.run(edit_config(Config, *args, **kwargs))
     return config_cli
 
 

--- a/src/eyconf/cli.py
+++ b/src/eyconf/cli.py
@@ -17,8 +17,10 @@ import os
 from typing import Annotated
 
 import typer
+from yaml import YAMLError
 
 from eyconf import EYConf
+from eyconf.validation import MultiConfigurationError
 
 
 def create_config_cli(
@@ -86,6 +88,22 @@ def create_config_cli(
     def edit():
         """Edit the configuration file in you default editor."""
         asyncio.run(edit_config(Config, *args, **kwargs))
+
+    @config_cli.command()
+    def validate():
+        """Validate the configuration file against the schema."""
+        try:
+            Config(*args, **kwargs)
+        except MultiConfigurationError as e:
+            for error in e.errors:
+                typer.echo(f"- {error}")
+            raise typer.Exit(1)
+        except YAMLError as e:
+            typer.echo("Invalid YAML file!")
+            typer.echo(e.__class__.__name__)
+            raise typer.Exit(1)
+
+        typer.echo("Configuration is valid.")
 
     return config_cli
 

--- a/src/eyconf/cli.py
+++ b/src/eyconf/cli.py
@@ -14,6 +14,7 @@ app.subcommand(config_cli, name="config")
 
 import asyncio
 import os
+from typing import Annotated
 
 import typer
 
@@ -61,9 +62,19 @@ def create_config_cli(
             print(ctx.get_help())
 
     @config_cli.command()
-    def ls():
+    def ls(
+        comments: Annotated[
+            bool,
+            typer.Option(help="Show the comments in returned configuration file."),
+        ] = False,
+    ):
         """Show the current configuration."""
+        path = Config.get_file()
         config = Config(*args, **kwargs)
+        if comments:
+            with open(path) as file:
+                config = file.read()
+
         typer.echo(str(config))
 
     @config_cli.command()

--- a/src/eyconf/cli.py
+++ b/src/eyconf/cli.py
@@ -16,7 +16,7 @@ import asyncio
 import difflib
 import os
 from contextlib import contextmanager
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 from rich import print
@@ -76,7 +76,7 @@ def create_config_cli(
     ):
         """Show the current configuration."""
         path = Config.get_file()
-        config = Config(*args, **kwargs)
+        config: EYConf[Any] | str = Config(*args, **kwargs)
         if comments:
             with open(path) as file:
                 config = file.read()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,3 +120,26 @@ class TestCommands:
         result = runner.invoke(cli_app, ["validate"])
         assert result.exit_code == 1
         assert "Additional properties are not allowed" in result.output
+
+    def test_diff(self, cli_app):
+        """Test the 'diff' command to show differences between current and default config."""
+        runner = CliRunner()
+        result = runner.invoke(cli_app, ["diff"])
+
+        assert result.exit_code == 0
+        # Should show "No changes!" when configs are identical
+        assert "No changes!" in result.output
+
+    def test_diff_with_changes(self, cli_app, mock_get_file_path):
+        """Test the 'diff' command with actual configuration changes."""
+        runner = CliRunner()
+
+        # Modify config file to have different values
+        with open(mock_get_file_path, "w") as f:
+            f.write("int_field: 100\nstr_field: 'Custom Value'\n")
+
+        result = runner.invoke(cli_app, ["diff"])
+
+        assert result.exit_code == 0
+        # Should show differences between default and current values
+        assert "+" in result.output or "-" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,3 +94,29 @@ class TestCommands:
 
         assert result.exit_code == 0
         assert "--help" in result.output
+
+    def test_validate(self, cli_app):
+        runner = CliRunner()
+        result = runner.invoke(cli_app, ["validate"])
+        assert result.exit_code == 0
+        assert "Configuration is valid." in result.output
+
+    def test_validate_invalid(self, cli_app, mock_get_file_path):
+        runner = CliRunner()
+
+        with open(mock_get_file_path, "a") as f:
+            f.write("invalid value")
+
+        result = runner.invoke(cli_app, ["validate"])
+        assert result.exit_code == 1
+        assert "Invalid YAML file!" in result.output
+
+    def test_validate_invalid_schema(self, cli_app, mock_get_file_path):
+        runner = CliRunner()
+
+        with open(mock_get_file_path, "a+") as f:
+            f.write("foo : 'bar'")
+
+        result = runner.invoke(cli_app, ["validate"])
+        assert result.exit_code == 1
+        assert "Additional properties are not allowed" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,3 +143,28 @@ class TestCommands:
         assert result.exit_code == 0
         # Should show differences between default and current values
         assert "+" in result.output or "-" in result.output
+
+    def test_reset(self, cli_app):
+        """Test the 'reset' command to reset configuration to defaults."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_app,
+            [
+                "reset",
+            ],
+            input="y\n",
+        )
+
+        assert result.exit_code == 0
+        assert "Configuration has been reset to default values." in result.output
+
+        # Exit if no confirm
+        result = runner.invoke(
+            cli_app,
+            [
+                "reset",
+            ],
+            input="N\n",
+        )
+        assert result.exit_code == 0
+        assert "Aborted!" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,57 +37,60 @@ def mock_get_file_path(tmp_path) -> Path:
     return config_file_path
 
 
-@pytest.fixture
 @skip
-def cli_app():
-    """Fixture to create a CLI app for the configuration commands."""
-    config_cli = create_config_cli(EYConf, schema=Config)
-    return config_cli
+class TestCommands:
+    @pytest.fixture
+    def cli_app(self):
+        """Fixture to create a CLI app for the configuration commands."""
+        config_cli = create_config_cli(EYConf, schema=Config)  # type: ignore
+        EYConf(Config)  # Instantiate the config to ensure file exists.
+        return config_cli
 
-
-@skip
-def test_main_command_shows_help(cli_app, mock_get_file_path):
-    """Test that invoking the main command without subcommands shows help."""
-    runner = CliRunner()
-    result = runner.invoke(cli_app, [])
-
-    assert result.exit_code == 0
-    assert "Manage configuration file" in result.output
-
-
-@skip
-def test_ls_command(cli_app, mock_get_file_path):
-    """Test the 'ls' command to list current configuration."""
-    runner = CliRunner()
-
-    # Instantiate the config to ensure file exists.
-    EYConf(Config)
-
-    result = runner.invoke(cli_app, ["ls"])
-
-    assert result.exit_code == 0
-    assert "int_field" in result.output
-    assert "str_field" in result.output
-
-
-@skip
-def test_edit_command(monkeypatch, cli_app, mock_get_file_path):
-    """Test the 'edit' command to open the configuration file in an editor."""
-
-    async def mock_asyncio_create_subprocess_exec(*args, **kwargs):
-        """Mock subprocess execution for opening a file."""
-
-        class MockProcess:
-            async def wait(self):
-                pass
-
-        return MockProcess()
-
-    with patch("asyncio.create_subprocess_exec", mock_asyncio_create_subprocess_exec):
+    @pytest.mark.parametrize("comments", [True, False])
+    def test_ls(self, cli_app, comments):
+        """Test the 'ls' command to list current configuration."""
         runner = CliRunner()
-        result = runner.invoke(cli_app, ["--edit"])
+        command = ["ls", "--comments"] if comments else ["ls"]
+        result = runner.invoke(cli_app, command)
 
-    print(result.output)  # For debugging purposes
+        assert result.exit_code == 0
+        assert "int_field" in result.output
+        assert "str_field" in result.output
 
-    assert result.exit_code == 0
-    assert "Opening configuration file:" in result.output
+    def test_path(self, cli_app):
+        """Test the 'path' command to show configuration path"""
+        runner = CliRunner()
+
+        result = runner.invoke(cli_app, ["path"])
+
+        assert result.exit_code == 0
+        assert os.environ["EYCONF_CONFIG_FILE"] in result.output
+
+    def test_edit(self, cli_app):
+        """Test the 'edit' command to open the configuration file in an editor."""
+
+        async def mock_asyncio_create_subprocess_exec(*args, **kwargs):
+            """Mock subprocess execution for opening a file."""
+
+            class MockProcess:
+                async def wait(self):
+                    pass
+
+            return MockProcess()
+
+        with patch(
+            "asyncio.create_subprocess_exec", mock_asyncio_create_subprocess_exec
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli_app, ["edit"])
+
+        assert result.exit_code == 0
+        assert "Opening configuration file:" in result.output
+
+    def test_help_default(self, cli_app):
+        """Should show the help if no command is given"""
+        runner = CliRunner()
+        result = runner.invoke(cli_app)
+
+        assert result.exit_code == 0
+        assert "--help" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,7 +93,7 @@ class TestCommands:
         result = runner.invoke(cli_app)
 
         assert result.exit_code == 0
-        assert "--help" in result.output
+        assert "Manage configuration file" in result.output
 
     def test_validate(self, cli_app):
         runner = CliRunner()


### PR DESCRIPTION
Adds a number of new subcommands to the cli:
- `path`: Show to the path of the configuration file
- `validate`: Validates the config file and show human readable erros
- `diff`: Shows a diff of the config against its default values
- `reset`: Allows to reset the config to default values

Improves some existing commands:
- `ls`: Allow to print config with and without comments
- `--edit`: Is now subcommand `edit

closes #12 