### PR TITLE
Use schema default values in validation (Eyconf file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2]
+
+* Enhanced the eyconf class to use schema-defined default values during validation, preventing errors when fields have defaults but aren't explicitly marked as optional.
+
 ## [0.5.1]
 
 * Access Proxies now support assignment of other acess proxies, comparison, and deepcopy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.5.1]
 
-* Access Proxies now support assignment of other acess proxies, comparison, and deepcopy.
+* Access Proxies now support assignment of other access proxies, comparison, and deepcopy.
 
 ## [0.5.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [0.5.2]
 
 * Enhanced the eyconf class to use schema-defined default values during validation, preventing errors when fields have defaults but aren't explicitly marked as optional.
+* Added py.typed marker to distribution
 
 ## [0.5.1]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,14 @@ cli = ["typer"]
 [tool.hatch.build.targets.wheel]
 packages = ["src/eyconf"]
 
+[tool.hatch.build.targets.sdist]
+include = [
+  "/src/**/*.py",
+  "/tests",
+  "/src/eyconf/py.typed"
+]
+
+
 [tool.ruff]
 include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "F. Paul Spitzner", email = "github@makeitso.one" },
 ]
 name = "eyconf"
-version = "0.5.1"
+version = "0.5.2"
 description = "Easy Yaml based Configuration for Python"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/eyconf/config/extra_fields.py
+++ b/src/eyconf/config/extra_fields.py
@@ -135,6 +135,7 @@ class AccessProxy(Generic[D]):
 
     def __hash__(self) -> int:
         """Make Access Proxy hashable by recursively hashing its internal data."""
+
         def make_hashable(obj):
             if isinstance(obj, dict):
                 return tuple(sorted((k, make_hashable(v)) for k, v in obj.items()))

--- a/src/eyconf/config/file.py
+++ b/src/eyconf/config/file.py
@@ -17,8 +17,10 @@ from typing import (
 
 import yaml
 
+from eyconf.asdict import asdict_with_aliases
 from eyconf.utils import (
     dataclass_from_dict,
+    merge_dicts,
 )
 from eyconf.validation import to_json_schema, validate_json
 
@@ -129,9 +131,11 @@ class EYConf(Config[D]):
                 f"Configuration file '{self.path.absolute()}' not found. Please generate with `write_default()`."
             )
 
-        # Load the config file
+        # We load the schema first to allow for sane default merging
+        # -> Load defaults, then merge with file contents
+        data: dict = asdict_with_aliases(self._schema())
         with open(self.path) as file:
-            data = yaml.safe_load(file)
+            data = merge_dicts(data, yaml.safe_load(file), priority="b")
 
         # Will raise ConfigurationError if the data does not comply with the schema
         validate_json(data, self._json_schema)

--- a/src/eyconf/utils.py
+++ b/src/eyconf/utils.py
@@ -46,12 +46,9 @@ def merge_dicts(
                 elif priority == "b":
                     # Use b's value, overwriting a's value
                     a[key] = val_b
-                elif priority == "raise":
-                    # Build error message only when needed
+                else:
                     full_path = ".".join(path_tuple + (str(key),))
                     raise Exception(f"Conflict at {full_path}: {val_a} != {val_b}")
-                else:
-                    raise ValueError(f"Invalid priority value: {priority}")
         else:
             a[key] = val_b
 

--- a/src/eyconf/utils.py
+++ b/src/eyconf/utils.py
@@ -7,6 +7,7 @@ from types import NoneType, UnionType
 from typing import (
     TYPE_CHECKING,
     Any,
+    Literal,
     TypedDict,
     TypeVar,
     get_args,
@@ -23,22 +24,34 @@ D = TypeVar("D", bound="DataclassInstance")
 T = TypeVar("T")
 
 
-def merge_dicts(a: dict, b: dict, path=[]):
+def merge_dicts(
+    a: dict, b: dict, path=[], priority: Literal["raise", "a", "b"] = "raise"
+) -> dict:
     """Merge dict b into dict a, raising an exception on conflicts."""
+    # Convert path to tuple for faster concatenation
+    path_tuple = tuple(path)
+
     for key in b:
         val_b = b[key]
         if key in a:
-            if isinstance(a[key], dict) and isinstance(b[key], dict):
-                merge_dicts(a[key], b[key], path + [str(key)])
             val_a = a[key]
+            # Handle nested dictionaries recursively
             if isinstance(val_a, dict) and isinstance(val_b, dict):
-                merge_dicts(val_a, val_b, path + [str(key)])
+                merge_dicts(val_a, val_b, path_tuple + (str(key),), priority)
             elif val_a != val_b:
-                raise Exception(
-                    "Conflict at "
-                    + ".".join(path + [str(key)])
-                    + f": {val_a} != {val_b}"
-                )
+                # Handle conflicts based on priority
+                if priority == "a":
+                    # Keep a's value, ignore b's value
+                    continue
+                elif priority == "b":
+                    # Use b's value, overwriting a's value
+                    a[key] = val_b
+                elif priority == "raise":
+                    # Build error message only when needed
+                    full_path = ".".join(path_tuple + (str(key),))
+                    raise Exception(f"Conflict at {full_path}: {val_a} != {val_b}")
+                else:
+                    raise ValueError(f"Invalid priority value: {priority}")
         else:
             a[key] = val_b
 

--- a/tests/test_config_extra_fields.py
+++ b/tests/test_config_extra_fields.py
@@ -214,7 +214,7 @@ class TestAccessProxy:
                 "int_field": 42,
                 "str_field": "FortyTwo!",
                 "lorem": "ipsum",
-            }
+            },
         }
 
     def test_item_assignment(self, proxy):
@@ -283,7 +283,7 @@ class TestAccessProxy:
 
     def test_hash(self):
         config_data = Config42()
-        extra_data: dict[str, Any] = dict(list_for_hash=[1,2,3])
+        extra_data: dict[str, Any] = dict(list_for_hash=[1, 2, 3])
         proxy = AccessProxy(
             config_data,
             extra_data,
@@ -291,7 +291,6 @@ class TestAccessProxy:
 
         proxy_2 = deepcopy(proxy)
         assert hash(proxy_2) == hash(proxy)
-
 
 
 class TestReset:

--- a/tests/test_eyconf_file.py
+++ b/tests/test_eyconf_file.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 from pathlib import Path
 
@@ -18,7 +18,7 @@ def tmp_config_path(tmp_path) -> Path:
 @dataclass
 class Config42:
     int_field: int = 42
-    str_field: str = "FortyTwo!"
+    str_field: str = field(default="FortyTwo!")
 
 
 class TestEYConfFile:
@@ -98,3 +98,9 @@ class TestEYConfFile:
         assert "EYConf" in repr_str
         assert "int_field" in repr_str
         assert "str_field" in repr_str
+
+    def test_default_validate(self, tmp_config_path):
+        with open(tmp_config_path, "w") as f:
+            f.write("int_field: 5\n")  # omit str_field to use default
+        conf = EYConf(Config42)
+        conf._data.str_field = "FortyTwo!"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -276,3 +276,15 @@ class TestMergeDicts:
         result = merge_dicts(a, b)
         assert a is result  # Should be the same object
         assert "new" in a  # Should have modified the original
+
+    def test_merge_with_priority_a(self):
+        a = {"key": "value1"}
+        b = {"key": "value2"}
+        result = merge_dicts(a, b, priority="a")
+        assert result == {"key": "value1"}
+
+    def test_merge_with_priority_b(self):
+        a = {"key": "value1"}
+        b = {"key": "value2"}
+        result = merge_dicts(a, b, priority="b")
+        assert result == {"key": "value2"}


### PR DESCRIPTION
 Enhanced the eyconf class to use schema-defined default values during validation, preventing errors when fields have defaults but aren't explicitly marked as optional.
 
 closes #20 