### PR TITLE
Fixed issue where `dataclass_to_yaml` would not generate valid YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.1]
+
+* Fixed issue where `generate_yaml` would not generate valid YAML when a dataclass with `None` union type was provided
+
 ## [0.6.0]
 
 * Added new subcommands to the CLI integration:`path`, `validate`, `diff`, `reset`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "F. Paul Spitzner", email = "github@makeitso.one" },
 ]
 name = "eyconf"
-version = "0.6.0"
+version = "0.6.1"
 description = "Easy Yaml based Configuration for Python"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/eyconf/generate_yaml.py
+++ b/src/eyconf/generate_yaml.py
@@ -159,30 +159,27 @@ def _dataclass_to_lines(
         include_extras=True,
     )
     all_fields = fields(schema)
+    is_instance = __is_dataclass_instance(schema)
 
-    # Handle dataclass instances
-    if __is_dataclass_instance(schema):
-        dict = schema.__dict__
-
-        for field, (key, value) in zip(all_fields, dict.items()):
-            dataclass_types[field.name]
-
-            lines += __field_to_lines(
-                field,
-                dataclass_types[field.name],
-                default_value=value,
-                indent=indent,
-            )
-
-        return lines
-
+    # Process each field
     for field in all_fields:
-        lines += __field_to_lines(field, dataclass_types[field.name], indent=indent)
+        field_type = dataclass_types[field.name]
+        default_value = _MISSING_SENTINEL
+
+        if is_instance:
+            # Get value from instance
+            default_value = getattr(schema, field.name, _MISSING_SENTINEL)
+
+        lines += __field_to_lines(
+            field,
+            field_type,
+            default_value=default_value,
+            indent=indent,
+        )
 
     return lines
 
 
-# Parse default
 _MISSING_SENTINEL = object()
 
 

--- a/src/eyconf/generate_yaml.py
+++ b/src/eyconf/generate_yaml.py
@@ -152,13 +152,6 @@ def _dataclass_to_lines(
         lines += __split_docstring(schema.__doc__, indent=indent)
         lines.append(EmptyLine())
 
-    # Handle dataclass instances
-    if __is_dataclass_instance(schema):
-        dict = schema.__dict__
-        for key, value in dict.items():
-            lines.append(MapLine(name=key, default_value=value, indent=indent))
-        return lines
-
     # Handle dataclass types
     # by parsing type hint
     dataclass_types = get_type_hints_resolve_namespace(
@@ -167,13 +160,38 @@ def _dataclass_to_lines(
     )
     all_fields = fields(schema)
 
+    # Handle dataclass instances
+    if __is_dataclass_instance(schema):
+        dict = schema.__dict__
+
+        for field, (key, value) in zip(all_fields, dict.items()):
+            dataclass_types[field.name]
+
+            lines += __field_to_lines(
+                field,
+                dataclass_types[field.name],
+                default_value=value,
+                indent=indent,
+            )
+
+        return lines
+
     for field in all_fields:
         lines += __field_to_lines(field, dataclass_types[field.name], indent=indent)
 
     return lines
 
 
-def __field_to_lines(field: Field[Any], field_type: type, indent=0) -> list[Line]:
+# Parse default
+_MISSING_SENTINEL = object()
+
+
+def __field_to_lines(
+    field: Field[Any],
+    field_type: type,
+    default_value: Any = _MISSING_SENTINEL,
+    indent=0,
+) -> list[Line]:
     """Parse a primitive field and return a list of lines.
 
     Parameters
@@ -204,13 +222,6 @@ def __field_to_lines(field: Field[Any], field_type: type, indent=0) -> list[Line
         for annotation in annotations:
             lines += __split_docstring(annotation, indent=indent)
 
-    if is_dataclass(field_type):
-        # Add section
-        lines.append(SectionLine(field.name, indent=indent))
-        lines += _dataclass_to_lines(field_type, indent=indent + 1)
-        lines.append(EmptyLine())
-        return lines
-
     # Check if field is optional
     is_optional = False
     if origin is UnionType:
@@ -218,32 +229,35 @@ def __field_to_lines(field: Field[Any], field_type: type, indent=0) -> list[Line
         args = tuple(
             arg for arg in args if arg is not type(None) and arg is not NoneType
         )
-
-    # Parse default
-    default_missing = True
-    default_value: Any = None
-    if isinstance(field.default, _MISSING_TYPE):
-        if isinstance(field.default_factory, _MISSING_TYPE):
-            default_missing = True
-        else:
+    if default_value is _MISSING_SENTINEL:
+        if not isinstance(field.default, _MISSING_TYPE):
+            default_value = field.default
+        elif not isinstance(field.default_factory, _MISSING_TYPE):
             default_value = field.default_factory()
-            default_missing = False
-    else:
-        default_value = field.default
-        default_missing = False
-
-    if origin in [dict, dict] and default_missing:
-        default_value = {}
-        default_missing = False
+        # Special cases default is missing but for usability
+        # we manually set it
+        # - dicts
+        # - dataclasses
+        elif origin in [dict]:
+            default_value = {}
+        elif is_dataclass(field_type):
+            default_value = field_type
 
     # No default value only allowed if the field is optional
-    if default_missing and not is_optional:
-        raise ValueError(
-            f"Field '{field.name}' has no default value! You may set one using direct assignment or a default factory."
-        )
+    if default_value is _MISSING_SENTINEL:
+        default_value = None
+        if not is_optional:
+            raise ValueError(
+                f"Field '{field.name}' has no default value! You may set one using direct assignment or a default factory."
+            )
 
-    # Default value: Lists/Sequences
-    if isinstance(default_value, list):
+    if is_dataclass(default_value):
+        # Default value: Datclasses
+        lines.append(SectionLine(field.name, indent=indent))
+        lines += _dataclass_to_lines(default_value, indent=indent + 1)
+        lines.append(EmptyLine())
+    elif isinstance(default_value, list):
+        # Default value: Lists/Sequences
         if len(default_value) == 0:
             default_value = None
         else:
@@ -267,17 +281,13 @@ def __field_to_lines(field: Field[Any], field_type: type, indent=0) -> list[Line
                 raise NotImplementedError(
                     f"Field type {field.type} {args} {origin} is not supported."
                 )
-
-            return lines
-
-    # Default value: dicts
-    if isinstance(default_value, dict):
+    elif isinstance(default_value, dict):
+        # Default value: dicts
         if len(default_value) == 0:
             """
             Stuff: {}
             """
             lines.append(MapLine(name=field.name, default_value=r"{}", indent=indent))
-            return lines
         else:
             """
             Stuff:
@@ -304,19 +314,18 @@ def __field_to_lines(field: Field[Any], field_type: type, indent=0) -> list[Line
                     f"Field type {field.type} {args} {origin} is not supported."
                 )
 
-            return lines
-
-    # Might not type check but it is a good enough heuristic
-    # if default_value is set wrongly there are more issues anyways
-    if __is_primitive_instance(default_value) or is_optional:
+    elif __is_primitive_instance(default_value) or is_optional:
+        # Might not type check but it is a good enough heuristic
+        # if default_value is set wrongly there are more issues anyways
         lines.append(
             MapLine(name=field.name, default_value=default_value, indent=indent)
         )
-        return lines
+    else:
+        raise NotImplementedError(
+            f"Field type {field.type} {args} {origin} is not supported."
+        )
 
-    raise NotImplementedError(
-        f"Field type {field.type} {args} {origin} is not supported."
-    )
+    return lines
 
 
 def __split_docstring(docstring: str, l=80, indent=0) -> list[Line]:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -130,6 +130,7 @@ class TestGenerateDefault:
         class Lists:
             int_list: list[int] | None
             str_list: list[str] = field(default_factory=lambda: ["a", "b", "c"])
+            str_list_2: list[str] = field(default_factory=lambda: [])
 
         yaml_str = dataclass_to_yaml(Lists)
         print(yaml_str)
@@ -276,6 +277,26 @@ class TestGenerateDefault:
         print(yaml_str)
         assert True
 
+    def test_optional_nested(self):
+        @dataclass
+        class Nested:
+            foo: str = "bar"
+
+        @dataclass
+        class Schema:
+            nested: Nested | None = field(default_factory=Nested)
+
+        yaml_str = dataclass_to_yaml(Schema)
+        assert yaml_str == "nested:\n  foo: bar\n"
+
+    def test_no_default(self):
+        @dataclass
+        class SchemaStrict:
+            foo: str
+
+        with pytest.raises(ValueError, match="has no default value!"):
+            dataclass_to_yaml(SchemaStrict)
+
 
 class TestDocstringGeneration:
     """Test generation of docstrings from dataclass fields."""
@@ -379,5 +400,6 @@ class TestDocstringGeneration:
             "  # Test\n"
             "  multi: 42\n"
         )
+        print(yaml_str)
         assert yaml_str == expected_yaml
         assert yaml.safe_load(yaml_str) == {"inner": {"single": 42, "multi": 42}}


### PR DESCRIPTION
The `dataclass_to_yaml` function currently fails to produce valid YAML when processing dataclass fields typed as optional (`Type | None`) where `Type` is itself a dataclass.

Given the following dataclasses:

```python
@dataclass
class SpotifyConfig:
    client_id: str = field(default="asd")
    client_secret: str | None = None

@dataclass
class ServicesConfig:
    spotify: SpotifyConfig | None = field(default_factory=lambda: SpotifyConfig())
```

Running `dataclass_to_yaml(ServicesConfig())` produces:

```yaml
spotify: SpotifyConfig(enabled=False, client_id='3b408bca2c3344dfa1cda1c7fa9adde4', client_secret=None)
```


Now it generates:

```yaml
spotify:
  client_id: asd
  client_secret: null
```

